### PR TITLE
fix: 🐛 area stacked firefox fix

### DIFF
--- a/packages/charts/src/charts/line/line-chart.utils.ts
+++ b/packages/charts/src/charts/line/line-chart.utils.ts
@@ -466,7 +466,7 @@ export const generateStackLines = ({
         areas.push({
           firstOpacity: 0.7,
           lastOpacity: 0.3,
-          d: `${generatePath(areaData.firstDataPart)},L${generatePath(
+          d: `${generatePath(areaData.firstDataPart)} L${generatePath(
             areaData.secondDataPart
           ).substring(1)}`,
         });


### PR DESCRIPTION
Closes: #279