### PR TITLE
fix: 🐛 chart paint

### DIFF
--- a/packages/charts/src/charts/donut/donut-chart.component.tsx
+++ b/packages/charts/src/charts/donut/donut-chart.component.tsx
@@ -8,7 +8,7 @@ import { getTooltipContent } from '../../utils/tooltip.utils';
 import DonutSlice from './donut-slice.component';
 import ShadowFilter from '../../components/shadow-filter.component';
 
-import { ChartBase } from '../../components';
+import { ChartBase, Delayed } from '../../components';
 import DonutTotal from './donut-total.component';
 
 import { useTooltip } from '../../hooks';
@@ -132,66 +132,68 @@ export const DonutChart: FC<Props> = ({
           </motion.div>
         )}
       </AnimatePresence>
-      <ChartBase
-        ref={svgElement}
-        theme={theme}
-        svgDimensions={svgDimensions}
-        margins={margins}
-      >
-        <g
-          style={{
-            transform: `translate(${svgDimensions.width /
-              2}px, ${svgDimensions.height / 2}px)`,
-          }}
+      <Delayed>
+        <ChartBase
+          ref={svgElement}
+          theme={theme}
+          svgDimensions={svgDimensions}
+          margins={margins}
         >
-          <ShadowFilter />
-          <AnimatePresence>
-            {arcs.map(
-              ({
-                dataKey,
-                label,
-                labelPosition,
-                activePosition,
-                startAngle,
-                endAngle,
-                color,
-                selector,
-                stacked,
-                stack,
-              }) => (
-                <DonutSlice
-                  key={dataKey}
-                  draw={drawArc}
-                  startAngle={startAngle}
-                  endAngle={endAngle}
-                  label={label}
-                  autocolor={labelsAutocolor}
-                  activePosition={activePosition}
-                  labelPosition={labelPosition}
-                  background={color}
-                  onMouseMove={e => {
-                    if (tooltipSettings.enabled) {
-                      if (stacked) updateTooltipPosition(e, stack);
-                      else updateTooltipPosition(e, [{ color, selector }]);
-                    }
-                  }}
-                  onMouseLeave={() => hideTooltip()}
-                />
-              )
+          <g
+            style={{
+              transform: `translate(${svgDimensions.width /
+                2}px, ${svgDimensions.height / 2}px)`,
+            }}
+          >
+            <ShadowFilter />
+            <AnimatePresence>
+              {arcs.map(
+                ({
+                  dataKey,
+                  label,
+                  labelPosition,
+                  activePosition,
+                  startAngle,
+                  endAngle,
+                  color,
+                  selector,
+                  stacked,
+                  stack,
+                }) => (
+                  <DonutSlice
+                    key={dataKey}
+                    draw={drawArc}
+                    startAngle={startAngle}
+                    endAngle={endAngle}
+                    label={label}
+                    autocolor={labelsAutocolor}
+                    activePosition={activePosition}
+                    labelPosition={labelPosition}
+                    background={color}
+                    onMouseMove={e => {
+                      if (tooltipSettings.enabled) {
+                        if (stacked) updateTooltipPosition(e, stack);
+                        else updateTooltipPosition(e, [{ color, selector }]);
+                      }
+                    }}
+                    onMouseLeave={() => hideTooltip()}
+                  />
+                )
+              )}
+            </AnimatePresence>
+            {totalEnabled && (
+              <DonutTotal
+                total={{
+                  label: donutTotalLabel.typography,
+                  value: donutTotalValue.typography,
+                }}
+              >
+                {totalValue}
+              </DonutTotal>
             )}
-          </AnimatePresence>
-          {totalEnabled && (
-            <DonutTotal
-              total={{
-                label: donutTotalLabel.typography,
-                value: donutTotalValue.typography,
-              }}
-            >
-              {totalValue}
-            </DonutTotal>
-          )}
-        </g>
-      </ChartBase>
+          </g>
+        </ChartBase>
+      </Delayed>
     </>
   );
 };

--- a/packages/charts/src/charts/pie/pie-chart.component.tsx
+++ b/packages/charts/src/charts/pie/pie-chart.component.tsx
@@ -8,7 +8,7 @@ import { getTooltipContent } from '../../utils/tooltip.utils';
 import PieSlice from './pie-slice.component';
 import ShadowFilter from '../../components/shadow-filter.component';
 
-import { ChartBase } from '../../components';
+import { ChartBase, Delayed } from '../../components';
 
 import { useTooltip } from '../../hooks';
 import { theme as defaultTheme } from '../../theme';
@@ -126,56 +126,58 @@ export const PieChart: FC<Props> = ({
           </motion.div>
         )}
       </AnimatePresence>
-      <ChartBase
-        ref={svgElement}
-        theme={theme}
-        svgDimensions={svgDimensions}
-        margins={margins}
-      >
-        <g
-          style={{
-            transform: `translate(${svgDimensions.width /
-              2}px, ${svgDimensions.height / 2}px)`,
-          }}
+      <Delayed>
+        <ChartBase
+          ref={svgElement}
+          theme={theme}
+          svgDimensions={svgDimensions}
+          margins={margins}
         >
-          <ShadowFilter />
-          <AnimatePresence>
-            {arcs.map(
-              ({
-                label,
-                labelPosition,
-                activePosition,
-                dataKey,
-                startAngle,
-                endAngle,
-                color,
-                selector,
-                stacked,
-                stack,
-              }) => (
-                <PieSlice
-                  key={dataKey}
-                  draw={drawArc}
-                  startAngle={startAngle}
-                  endAngle={endAngle}
-                  label={label}
-                  autocolor={labelsAutocolor}
-                  activePosition={activePosition}
-                  labelPosition={labelPosition}
-                  background={color}
-                  onMouseMove={e => {
-                    if (tooltipSettings.enabled) {
-                      if (stacked) updateTooltipPosition(e, stack);
-                      else updateTooltipPosition(e, [{ color, selector }]);
-                    }
-                  }}
-                  onMouseLeave={() => hideTooltip()}
-                />
-              )
-            )}
-          </AnimatePresence>
-        </g>
-      </ChartBase>
+          <g
+            style={{
+              transform: `translate(${svgDimensions.width /
+                2}px, ${svgDimensions.height / 2}px)`,
+            }}
+          >
+            <ShadowFilter />
+            <AnimatePresence>
+              {arcs.map(
+                ({
+                  label,
+                  labelPosition,
+                  activePosition,
+                  dataKey,
+                  startAngle,
+                  endAngle,
+                  color,
+                  selector,
+                  stacked,
+                  stack,
+                }) => (
+                  <PieSlice
+                    key={dataKey}
+                    draw={drawArc}
+                    startAngle={startAngle}
+                    endAngle={endAngle}
+                    label={label}
+                    autocolor={labelsAutocolor}
+                    activePosition={activePosition}
+                    labelPosition={labelPosition}
+                    background={color}
+                    onMouseMove={e => {
+                      if (tooltipSettings.enabled) {
+                        if (stacked) updateTooltipPosition(e, stack);
+                        else updateTooltipPosition(e, [{ color, selector }]);
+                      }
+                    }}
+                    onMouseLeave={() => hideTooltip()}
+                  />
+                )
+              )}
+            </AnimatePresence>
+          </g>
+        </ChartBase>
+      </Delayed>
     </>
   );
 };

--- a/packages/charts/src/components/delayed/delayed.component.tsx
+++ b/packages/charts/src/components/delayed/delayed.component.tsx
@@ -1,0 +1,15 @@
+import React, { FC, useState, useEffect } from 'react';
+
+type Props = {
+  /** React children nodes */
+  children: React.ReactNode;
+};
+
+const Delayed: FC<Props> = ({ children }) => {
+  const [visible, setVisibility] = useState(false);
+  useEffect(() => setVisibility(true), []);
+
+  return <>{visible && children}</>;
+};
+
+export default Delayed;

--- a/packages/charts/src/components/delayed/index.ts
+++ b/packages/charts/src/components/delayed/index.ts
@@ -1,0 +1,3 @@
+import Delayed from './delayed.component';
+
+export default Delayed;

--- a/packages/charts/src/components/index.ts
+++ b/packages/charts/src/components/index.ts
@@ -5,6 +5,7 @@ import ChartTooltip from './chart-tooltip';
 import HoverBar, { hoverBarMotion } from './hover-bar';
 import { Mark, markMotion } from './mark';
 import PieLabel from './pie-label';
+import Delayed from './delayed';
 
 import Axes from './axes.component';
 import Grid from './grid.component';
@@ -13,6 +14,7 @@ import { LegendCard, LegendBase, SeriesLegend, BubbleLegend } from './legend';
 export {
   ChartBase,
   ChartTooltip,
+  Delayed,
   PieLabel,
   ResponsiveWrapper,
   HoverBar,

--- a/packages/charts/src/components/legend/slider/button.styles.ts
+++ b/packages/charts/src/components/legend/slider/button.styles.ts
@@ -32,9 +32,11 @@ export const Gradient = styled(motion.div)<{
   transmition: string;
   variant: Variant;
 }>`
-  position: absolute;
   top: 0;
-  ${props => getDimension(props.variant)}
+  position: absolute;
+
+  ${props => getDimension(props.variant)};
+
   background-image: linear-gradient(
     ${props => props.transmition},
     ${colors.white['400']},
@@ -56,14 +58,14 @@ export const Block = styled.div<{
   shadow: string;
 }>`
   position: absolute;
-  ${props => getPosition(props.position)}
+  ${props => getPosition(props.position)};
 
-  background: ${colors.white['500']}
+  background: ${colors.white['500']};
 
   display: flex;
   justify-content: center;
   align-items: center;
-  ${props => getDimension(props.variant)}
+  ${props => getDimension(props.variant)};
   ${props =>
     !props.disabled &&
     css`

--- a/packages/dataviz/src/stories/pie-chart.stories.tsx
+++ b/packages/dataviz/src/stories/pie-chart.stories.tsx
@@ -76,7 +76,7 @@ export const singleResult = () => {
       .then((res: any) => dataviz.render(res));
   }, []);
 
-  return <div style={{ width: '400px', height: '300px' }} ref={container} />;
+  return <div style={{ width: '600px', height: '450px' }} ref={container} />;
 };
 
 export const simpleResults = () => {
@@ -107,7 +107,7 @@ export const simpleResults = () => {
       .then((res: any) => dataviz.render(res));
   }, []);
 
-  return <div style={{ width: '400px', height: '300px' }} ref={container} />;
+  return <div style={{ width: '600px', height: '450px' }} ref={container} />;
 };
 
 export const multipleResults = () => {
@@ -138,5 +138,5 @@ export const multipleResults = () => {
       .then((res: any) => dataviz.render(res));
   }, []);
 
-  return <div style={{ width: '400px', height: '300px' }} ref={container} />;
+  return <div style={{ width: '600px', height: '450px' }} ref={container} />;
 };


### PR DESCRIPTION
added delayed component to avoid chart base reflow after legend is
extended to two line mode