### PR TITLE
fix: 🐛 enable tooltip for markRadius equals to 0

### DIFF
--- a/packages/charts/src/charts/line/marks.component.tsx
+++ b/packages/charts/src/charts/line/marks.component.tsx
@@ -14,6 +14,15 @@ const pointMotion = {
   transition: { delay: 1.2, duration: 0.3 },
 };
 
+const getRadius = (radius: number) => {
+  return radius === 0
+    ? {
+        r: 1,
+        fillOpacity: 0,
+      }
+    : { r: radius };
+};
+
 type Props = {
   marks: Mark[];
   steps: StepType[];
@@ -56,6 +65,7 @@ const Marks = ({
               cy={y}
               r={radius}
               fill={color}
+              {...getRadius(radius)}
               {...pointMotion}
             />
             <AnimatePresence>


### PR DESCRIPTION
https://metakeen.atlassian.net/browse/FRON-81