### PR TITLE
fix: 🐛 add support for svg transform in Safari

### DIFF
--- a/packages/icons/src/components/button-arrow-left.component.tsx
+++ b/packages/icons/src/components/button-arrow-left.component.tsx
@@ -3,15 +3,10 @@ import React from 'react';
 import { IconProps } from '../types';
 
 const ButtonArrowLeft = ({ width, height, opacity, fill }: IconProps) => (
-  <svg
-    width={width}
-    height={height}
-    opacity={opacity}
-    transform="rotate(-180)"
-    viewBox="0 0 100 100"
-  >
+  <svg width={width} height={height} opacity={opacity} viewBox="0 0 100 100">
     <path
       fill={fill}
+      transform="rotate(180 50 50)"
       d="M73.31 23l26.662 26.662-27.266 27.266-2.51-2.51 23.384-23.39H0v-4h92.198l-21.456-21.46L73.309 23z"
     />
   </svg>


### PR DESCRIPTION
`transform` on SVG is not supported in Safari