### PR TITLE
fix: 🐛 export Point and ItemData types

### DIFF
--- a/packages/charts/src/charts/circular-chart/index.ts
+++ b/packages/charts/src/charts/circular-chart/index.ts
@@ -1,3 +1,4 @@
 import TooltipItem, { ItemData } from './tooltip-item.component';
 
-export { TooltipItem, ItemData };
+export { TooltipItem };
+export type { ItemData };

--- a/packages/charts/src/charts/circular-chart/tooltip-item.component.tsx
+++ b/packages/charts/src/charts/circular-chart/tooltip-item.component.tsx
@@ -5,11 +5,11 @@ import { Container } from './tooltip-item.styles';
 import { theme as defaultTheme } from '../../theme';
 import { Theme } from '../../types';
 
-export interface ItemData {
+export type ItemData = {
   label: string;
   value: string;
   change?: string;
-}
+};
 
 type Props = {
   /** Item data */

--- a/packages/ui-core/src/components/bullet-list/bullet-list.component.tsx
+++ b/packages/ui-core/src/components/bullet-list/bullet-list.component.tsx
@@ -6,10 +6,10 @@ import {
   BulletPoint,
 } from './bullet-list.styles';
 
-export interface Point {
+export type Point = {
   color: string;
   data: string | Record<string, any>;
-}
+};
 
 type Props<T> = {
   /** Collection of items */

--- a/packages/ui-core/src/components/bullet-list/index.ts
+++ b/packages/ui-core/src/components/bullet-list/index.ts
@@ -1,4 +1,4 @@
 import BulletList, { Point } from './bullet-list.component';
 
 export default BulletList;
-export { Point };
+export type { Point };

--- a/packages/ui-core/src/components/index.ts
+++ b/packages/ui-core/src/components/index.ts
@@ -74,6 +74,7 @@ export type {
   TooltipMode,
   OAuthConfig,
   DropableContainerVariant,
+  Point,
 };
 
 export {
@@ -84,7 +85,6 @@ export {
   ActionButton,
   CircleButton,
   BulletList,
-  Point,
   Card,
   Checkbox,
   ColorAdjuster,


### PR DESCRIPTION
fixes warning about missing export for types