### PR TITLE
fix: 🐛 Swapped z-index values of dropdown and tooltip

### DIFF
--- a/packages/ui-core/src/constants.ts
+++ b/packages/ui-core/src/constants.ts
@@ -1,8 +1,8 @@
 export const UI_LAYERS = {
   notification: 50,
   modal: 40,
-  dropdown: 30,
-  tooltip: 20,
+  tooltip: 30,
+  dropdown: 20,
   element: 10,
 };
 


### PR DESCRIPTION
Fixes the problem  in dashboard creator with disabledTimezoneSelection tooltip showing under timeframe dropdown