### PR TITLE
fix: 🐛 initial line height  in tooltip - missing property fix

### DIFF
--- a/packages/ui-core/src/components/tooltip/tooltip.component.test.tsx
+++ b/packages/ui-core/src/components/tooltip/tooltip.component.test.tsx
@@ -73,6 +73,7 @@ test('renders `dark-mode`', () => {
       font-family: 'Lato Regular',sans-serif;
       font-size: 14px;
       color: #3A494D;
+      line-height: initial;
       box-shadow: 0 10px 24px 0 rgba(29,39,41,0.15);
       position: relative;
       background-color: rgba(58,73,77,0.95);
@@ -126,6 +127,7 @@ test('not renders box shadow', () => {
       font-family: 'Lato Regular',sans-serif;
       font-size: 14px;
       color: #3A494D;
+      line-height: initial;
       box-shadow: none;
       position: relative;
       background-color: rgba(255,255,255,0.95);

--- a/packages/ui-core/src/components/tooltip/tooltip.component.tsx
+++ b/packages/ui-core/src/components/tooltip/tooltip.component.tsx
@@ -21,6 +21,7 @@ type Props = Partial<Typography> & {
   hasSpacing?: boolean;
   arrowDirection?: Position;
   arrowTop?: string;
+  lineHeight?: string;
 };
 
 const LIGHT_MODE_BACKGROUND = Color(colors.white['500'])
@@ -46,6 +47,7 @@ const Wrapper = styled.div<Props>`
   font-family: ${(props) => props.fontFamily};
   font-size: ${(props) => props.fontSize + 'px'};
   color: ${(props) => props.fontColor};
+  line-height: ${(props) => props.lineHeight};
   box-shadow: ${(props) =>
     props.hasShadow ? '0 10px 24px 0 rgba(29, 39, 41, 0.15)' : 'none'};
   position: relative;


### PR DESCRIPTION
[FEE-540](https://metakeen.atlassian.net/jira/software/projects/FEE/boards/10?selectedIssue=FEE-540)