### PR TITLE
fix: 🐛 Handling zero values in area gradient generator

### DIFF
--- a/packages/charts/src/charts/line/utils/gradient.utils.test.ts
+++ b/packages/charts/src/charts/line/utils/gradient.utils.test.ts
@@ -113,3 +113,22 @@ test('should generate correctly disabled gradient for the block stacked gradient
     }
   `);
 });
+
+test('should generate gradient percent value as zero when max positive value and min positive value are zero', () => {
+  const gradient = generateAreaGradient(
+    0,
+    0,
+    'red',
+    STACKED_GRADIENT.disabled.min,
+    STACKED_GRADIENT.disabled.max
+  );
+
+  expect(gradient).toMatchInlineSnapshot(`
+    Object {
+      "gradientZeroPercent": 0,
+      "negativeColor": "rgba(255, 0, 0, 0.125)",
+      "positiveColor": "rgba(255, 0, 0, 0.125)",
+      "zeroPointColor": "rgba(255, 0, 0, 0.125)",
+    }
+  `);
+});

--- a/packages/charts/src/charts/line/utils/gradient.utils.ts
+++ b/packages/charts/src/charts/line/utils/gradient.utils.ts
@@ -65,6 +65,8 @@ export const generateAreaGradient = (
   const positiveMax = isMaxNegative ? 0 : Math.abs(maxKeyNameValue);
   const positiveMin = isMinNegative ? Math.abs(minKeyNameValue) : 0;
   const maxValue = positiveMax > positiveMin ? positiveMax : positiveMin;
+  const minAndMaxValueAreZero = positiveMax === 0 && positiveMin === 0;
+
   const colorScale = scaleLinear<string>()
     .domain([0, maxValue])
     .range([
@@ -76,6 +78,8 @@ export const generateAreaGradient = (
     positiveColor: colorScale(positiveMax),
     zeroPointColor: colorScale(0),
     negativeColor: colorScale(positiveMin),
-    gradientZeroPercent: (positiveMax / (positiveMax + positiveMin)) * 100,
+    gradientZeroPercent: minAndMaxValueAreZero
+      ? 0
+      : (positiveMax / (positiveMax + positiveMin)) * 100,
   };
 };


### PR DESCRIPTION
[FEE-603](https://metakeen.atlassian.net/jira/software/projects/FEE/boards/10?selectedIssue=FEE-603)
Preventing 0/0 division, which outputs NaN