### PR TITLE
fix: 🐛 Color copy/paste enabled in typography

### DIFF
--- a/packages/ui-core/src/components/typography-settings/typography-settings.component.tsx
+++ b/packages/ui-core/src/components/typography-settings/typography-settings.component.tsx
@@ -46,7 +46,7 @@ const TypographySettings: FC<Props> = ({
   };
 
   return (
-    <Container onMouseDown={(e) => e.preventDefault()}>
+    <Container>
       {availableSettings.color && (
         <Color
           color={settings.color}


### PR DESCRIPTION
https://metakeen.atlassian.net/browse/FEE-779