### PR TITLE
fix: 🐛 handle delimeter in csv

### DIFF
--- a/packages/data-export/src/csv/export-to-csv.test.ts
+++ b/packages/data-export/src/csv/export-to-csv.test.ts
@@ -1,0 +1,15 @@
+import { exportToCSV } from './export-to-csv';
+
+test('some random description', () => {
+  const data = [
+    ['origin_country', 'U,S'],
+    ['business_name', 'Buz'],
+  ];
+  const result = exportToCSV(data);
+
+  expect(result).toMatchInlineSnapshot(`
+    "origin_country,\\"U,S\\"
+    business_name,Buz
+    "
+  `);
+});

--- a/packages/data-export/src/csv/export-to-csv.ts
+++ b/packages/data-export/src/csv/export-to-csv.ts
@@ -18,6 +18,11 @@ export const exportToCSV = (
   data.forEach((row: Array<string | number>) => {
     const transformedRow = row.map((item) => {
       if (item === null) return 'null';
+
+      const hasDelimeter =
+        typeof item === 'string' && item.includes(columnDelimiter);
+      if (hasDelimeter) return `"${item}"`;
+
       return item;
     });
     result += transformedRow.join(columnDelimiter) + lineDelimiter;


### PR DESCRIPTION
https://metakeen.atlassian.net/browse/FEE-897

this is how it looks in Explorer
<img width="987" alt="Screenshot 2022-04-28 at 10 34 36" src="https://user-images.githubusercontent.com/23423731/165713557-16df1700-980d-454e-b70b-eb698d786c69.png">

